### PR TITLE
mysql + s3 + opengpg implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+dev

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+SHELL = /bin/bash
+REG=quay.io
+ORG=integreatly
+IMAGE=backup-container
+TAG=latest
+
+image/build:
+	@(cd image; docker build -t ${REG}/${ORG}/${IMAGE}:${TAG} .)
+
+image/push:
+	@docker push ${REG}/${ORG}/${IMAGE}:${TAG}

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -11,6 +11,7 @@ RUN yum --enablerepo=extras install -y epel-release && \
     mv openshift-origin-*/* /usr/bin/
 
 COPY tools /opt/intly/tools
+RUN mkdir -p /opt/intly/output
 RUN chown -R 1001:root /opt/intly
 
 RUN find /opt/intly/tools -type f -exec chmod +x {} \; && \

--- a/image/tools/entrypoint.sh
+++ b/image/tools/entrypoint.sh
@@ -29,7 +29,7 @@ if [[ -z "$component" ]]; then
 fi
 
 source "$DIR/lib/backend/$archive_backend.sh"
-if [[ -n "$encryption_engine" ]]; then
+if [[ "$encryption_engine" ]]; then
     source "$DIR/lib/encryption/$encryption_engine.sh"
 fi
 source "$DIR/lib/component/$component.sh"
@@ -42,7 +42,7 @@ export HOME=$DEST
 
 component_dump_data $DEST
 echo '==> Component data dump completed'
-if [[ -n "$encryption_engine" ]]; then
+if [[ "$encryption_engine" ]]; then
     encrypt_prepare $DEST
     encrypted_files="$(encrypt_archive $ARCHIVES_DEST)"
     echo '==> Data encryption completed'
@@ -54,7 +54,7 @@ echo '==> Archive upload completed'
 
 echo "[$DATESTAMP] Backup completed"
 
-if [[ -n "$debug" ]]; then
+if [[ "$debug" ]]; then
     echo '==> Debug flag detected - will sleep for all eternity'
     sleep infinity
 fi

--- a/image/tools/entrypoint.sh
+++ b/image/tools/entrypoint.sh
@@ -32,17 +32,24 @@ source "$DIR/lib/backend/$archive_backend.sh"
 source "$DIR/lib/encryption/$encryption_engine.sh"
 source "$DIR/lib/component/$component.sh"
 
-timestamp="$(date '+%H:%M:%S')"
-fname="/tmp/archive-$timestamp"
+DATESTAMP=$(date '+%Y-%m-%d')
+DEST=/tmp/intly
+ARCHIVES_DEST=$DEST/archives
+mkdir -p $DEST $ARCHIVES_DEST
+export HOME=$DEST
 
-url=component_get_url
-component_dump_data $url $fname.tar.gz
-encrypt_archive $fname.tar.gz
-upload_archive $fname.tar.gz.encrypted
+component_dump_data $DEST
+echo '==> Component data dump completed'
+encrypt_prepare $DEST
+encrypted_files="$(encrypt_archive $ARCHIVES_DEST)"
+echo "$encrypted_files"
+echo '==> Data encryption completed'
+upload_archive $encrypted_files $DATESTAMP backups/$component
+echo '==> Archive upload completed'
 
-echo "[$timestamp] Backup completed"
+echo "[$DATESTAMP] Backup completed"
 
 if [[ -n "$debug" ]]; then
-    echo 'Debug flag detected - will sleep for all eternity'
+    echo '==> Debug flag detected - will sleep for all eternity'
     sleep infinity
 fi

--- a/image/tools/entrypoint.sh
+++ b/image/tools/entrypoint.sh
@@ -42,8 +42,8 @@ export HOME=$DEST
 
 component_dump_data $DEST
 echo '==> Component data dump completed'
-encrypt_prepare $DEST
 if [[ -n "$encryption_engine" ]]; then
+    encrypt_prepare $DEST
     encrypted_files="$(encrypt_archive $ARCHIVES_DEST)"
     echo '==> Data encryption completed'
 else

--- a/image/tools/entrypoint.sh
+++ b/image/tools/entrypoint.sh
@@ -29,7 +29,9 @@ if [[ -z "$component" ]]; then
 fi
 
 source "$DIR/lib/backend/$archive_backend.sh"
-source "$DIR/lib/encryption/$encryption_engine.sh"
+if [[ -n "$encryption_engine" ]]; then
+    source "$DIR/lib/encryption/$encryption_engine.sh"
+fi
 source "$DIR/lib/component/$component.sh"
 
 DATESTAMP=$(date '+%Y-%m-%d')
@@ -41,9 +43,12 @@ export HOME=$DEST
 component_dump_data $DEST
 echo '==> Component data dump completed'
 encrypt_prepare $DEST
-encrypted_files="$(encrypt_archive $ARCHIVES_DEST)"
-echo "$encrypted_files"
-echo '==> Data encryption completed'
+if [[ -n "$encryption_engine" ]]; then
+    encrypted_files="$(encrypt_archive $ARCHIVES_DEST)"
+    echo '==> Data encryption completed'
+else
+    encrypted_files="$ARCHIVES_DEST/*"
+fi
 upload_archive $encrypted_files $DATESTAMP backups/$component
 echo '==> Archive upload completed'
 

--- a/image/tools/lib/backend/s3.sh
+++ b/image/tools/lib/backend/s3.sh
@@ -4,7 +4,7 @@ function upload_archive {
     file_list=$1
     datestamp=$2
 
-    if [[ -n "$AWS_S3_BUCKET_SUFFIX" ]]; then
+    if [[ "$AWS_S3_BUCKET_SUFFIX" ]]; then
         bucket_folder="$3/$AWS_S3_BUCKET_SUFFIX"
     else 
         bucket_folder=$3

--- a/image/tools/lib/backend/s3.sh
+++ b/image/tools/lib/backend/s3.sh
@@ -1,5 +1,15 @@
 #required env vars: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and AWS_S3_BUCKET_NAME
 function upload_archive {
-    archive_path="$1"
-    echo "TODO: upload archive \"$archive_path\" using s3 cli"
+    file_list=$1
+    datestamp=$2
+    bucket_folder=$3
+
+    for fname in "$file_list"; do
+        s3cmd put --progress $fname "s3://$AWS_S3_BUCKET_NAME/$bucket_folder/$datestamp/$(basename $fname)"
+        rc=$?
+        if [ $rc -ne 0 ]; then
+            echo "==> Upload $name: FAILED"
+            exit 1
+        fi
+    done
 }

--- a/image/tools/lib/backend/s3.sh
+++ b/image/tools/lib/backend/s3.sh
@@ -1,8 +1,14 @@
 #required env vars: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and AWS_S3_BUCKET_NAME
+#optional env vars: AWS_S3_BUCKET_SUFFIX
 function upload_archive {
     file_list=$1
     datestamp=$2
-    bucket_folder=$3
+
+    if [[ -n "$AWS_S3_BUCKET_SUFFIX" ]]; then
+        bucket_folder="$3/$AWS_S3_BUCKET_SUFFIX"
+    else 
+        bucket_folder=$3
+    fi
 
     for fname in "$file_list"; do
         s3cmd put --progress $fname "s3://$AWS_S3_BUCKET_NAME/$bucket_folder/$datestamp/$(basename $fname)"

--- a/image/tools/lib/component/mysql.sh
+++ b/image/tools/lib/component/mysql.sh
@@ -1,8 +1,13 @@
-function component_get_url {
-    echo 'mysql://localhost'
-}
-
 function component_dump_data {
-    auth_url=$1
-    echo "Use $auth_url to archive mysql data"
+    dest=$1
+    databases=$(mysql -h$MYSQL_HOST -u$MYSQL_USER  -p$MYSQL_PASSWORD -e 'SHOW DATABASES' | tail -n+2 | grep -v information_schema)
+    for database in $databases; do
+        ts=$(date '+%H:%M:%S')
+        mysqldump -h$MYSQL_HOST -u$MYSQL_USER -p$MYSQL_PASSWORD -R $database | gzip > $dest/archives/$database-$ts.dump.gz
+        rc=$?
+        if [ $rc -ne 0 ]; then
+            echo "==> Dump $database: FAILED"
+            exit 1
+        fi
+    done
 }

--- a/image/tools/lib/encryption/gpg.sh
+++ b/image/tools/lib/encryption/gpg.sh
@@ -1,4 +1,24 @@
+function encrypt_prepare {
+    dest=$1/gpg
+    mkdir -p $dest
+    key_path=$dest/gpg_public_key
+    echo -e "$GPG_PUBLIC_KEY" > $key_path
+
+    gpg --import $key_path
+    gpg --list-keys
+}
+
 function encrypt_archive {
-    archive_path="$1"
-    echo "encrypt archive \"$archive_path\" using opengpg"
+    dest=$1
+
+    for fname in $dest/*; do
+        gpg --no-tty --batch --yes --encrypt --recipient "$GPG_RECIPIENT" --trust-model $GPG_TRUST_MODEL $fname
+        rc=$?
+        if [ $rc -ne 0 ]; then
+            echo "==> Encrypt $fname: FAILED"
+            exit 1
+        fi
+    done
+
+    echo "$dest/*.gpg"
 }

--- a/image/tools/lib/encryption/gpg.sh
+++ b/image/tools/lib/encryption/gpg.sh
@@ -7,7 +7,7 @@ function encrypt_prepare {
     gpg --import $key_path
     gpg --list-keys
 }
-
+ 
 function encrypt_archive {
     dest=$1
 

--- a/templates/openshift/README.md
+++ b/templates/openshift/README.md
@@ -14,7 +14,7 @@ Check the [smaple-config folder](./sample-config) for examples.
 
 Encryption within the backup pod is disabled by default, it can be enabled by adding the paramater: `-p 'ENCRYPTION=gpg'` and a valid openshift secret - you can check a sample secret definiton [here](./sample-config/gpg-secret).
 
-Note: You need to create an [empty secret](./sample-config/blank-secret) object and use as the `ENCRYPTION_SECRET_NAME` var value in case you want to skip opengp encryption, this is needed because the template mounts env var from an encryption secret name and the template processing will fail if this secret is not available.
+Note: You need to create an [empty secret](./sample-config/blank-secret) object and use as the `ENCRYPTION_SECRET_NAME` var value in case you want to skip opengpg encryption, this is needed because the template mounts env var from an encryption secret name and the template processing will fail if this secret is not available.
 
 ### Cronjob
 

--- a/templates/openshift/README.md
+++ b/templates/openshift/README.md
@@ -12,6 +12,10 @@ Both templates requires three secrets objects:
 
 Check the [smaple-config folder](./sample-config) for examples.
 
+Encryption within the backup pod is disabled by default, it can be enabled by adding the paramater: `-p 'ENCRYPTION=gpg'` and a valid openshift secret - you can check a sample secret definiton [here](./sample-config/gpg-secret).
+
+Note: You need to create an [empty secret](./sample-config/blank-secret) object and use as the `ENCRYPTION_SECRET_NAME` var value in case you want to skip opengp encryption, this is needed because the template mounts env var from an encryption secret name and the template processing will fail if this secret is not available.
+
 ### Cronjob
 
 Creates a backup cronjob:
@@ -24,7 +28,7 @@ oc new-app \
 -p 'BACKEND_SECRET_NAME=sample-s3-secret' \
 -p 'ENCRYPTION_SECRET_NAME=sample-gpg-secret' \
 -p 'IMAGE=quay.io/integreatly/backup-container:master' \
--p 'CRON_SCHEDULE=* */4 * * *' \
+-p 'CRON_SCHEDULE=* */1 * * *' \
 -p 'NAME=mysql-backup'
 ```
 
@@ -38,9 +42,9 @@ oc process \
 -p 'BACKEND_SECRET_NAME=sample-s3-secret' \
 -p 'ENCRYPTION_SECRET_NAME=sample-gpg-secret' \
 -p 'IMAGE=quay.io/integreatly/backup-container:master' \
--p 'CRON_SCHEDULE=* */4 * * *' \
+-p 'CRON_SCHEDULE=* */1 * * *' \
 -p 'NAME=mysql-backup' | oc apply -f -
-``` 
+```
 
 Parameters:
 

--- a/templates/openshift/backup-cronjob-template.yaml
+++ b/templates/openshift/backup-cronjob-template.yaml
@@ -55,7 +55,6 @@ parameters:
     value: s3
   - name: ENCRYPTION
     description: Encryption engine to encrypt component archive before uploading it
-    value: gpg
   - name: COMPONENT_SECRET_NAME
     description: Component secret name to create environment variables from
     required: true

--- a/templates/openshift/backup-job-template.yaml
+++ b/templates/openshift/backup-job-template.yaml
@@ -47,7 +47,6 @@ parameters:
     value: s3
   - name: ENCRYPTION
     description: Encryption engine to encrypt component archive before uploading it
-    value: gpg
   - name: COMPONENT_SECRET_NAME
     description: Component secret name to create environment variables from
     required: true

--- a/templates/openshift/backup-job-template.yaml
+++ b/templates/openshift/backup-job-template.yaml
@@ -34,6 +34,13 @@ objects:
                 - "${ENCRYPTION}"
                 - "-d"
                 - "${DEBUG}"
+              envFrom:
+                - secretRef:
+                    name: "${COMPONENT_SECRET_NAME}"
+                - secretRef:
+                    name: "${BACKEND_SECRET_NAME}"
+                - secretRef:
+                    name: "${ENCRYPTION_SECRET_NAME}"
           restartPolicy: Never
 parameters:
   - name: NAME

--- a/templates/openshift/rbac/role-binding.yaml
+++ b/templates/openshift/rbac/role-binding.yaml
@@ -6,4 +6,5 @@ roleRef:
   name: backupjob
 subjects:
   - kind: ServiceAccount
+    namespace: backup
     name: backupjob

--- a/templates/openshift/sample-config/blank-secret.yaml
+++ b/templates/openshift/sample-config/blank-secret.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sample-no-encryption-secret
+type: Opaque

--- a/templates/openshift/sample-config/gpg-secret.yaml
+++ b/templates/openshift/sample-config/gpg-secret.yaml
@@ -3,6 +3,10 @@ kind: Secret
 metadata:
   name: sample-gpg-secret
 type: Opaque 
+data:
+  GPG_PUBLIC_KEY: |
+    my multiline base64 encoded public opengpg cert
 stringData: 
-  GPG_RECIPIENT: myself
+  GPG_RECIPIENT: admin@example.com
   GPG_TRUST_MODEL: always
+  


### PR DESCRIPTION
Adds mysql, s3 and opengpg backup support.

#Verification steps

Deploy mysql:

```
oc new-app \
-e MYSQL_USER=admin  \
-e MYSQL_PASSWORD=admin 
-e MYSQL_DATABASE=dummy \
mysql:5.6
```

Create the required secrets:

```
apiVersion: v1
kind: Secret
metadata:
  name: sample-s3-secret
type: Opaque 
stringData: 
  AWS_S3_BUCKET_NAME: intly
  AWS_ACCESS_KEY_ID: my_aws_key
  AWS_SECRET_ACCESS_KEY: my_aws_access_key
```

```
apiVersion: v1
kind: Secret
metadata:
  name: sample-gpg-secret
type: Opaque 
data:
  GPG_PUBLIC_KEY: |
    my multiline base64 encoded public opengpg cert
stringData: 
  GPG_RECIPIENT: admin@example.com
  GPG_TRUST_MODEL: always
```

```
apiVersion: v1
kind: Secret
metadata:
  name: sample-mysql-secret
type: Opaque 
stringData: 
  MYSQL_HOST: mysql.ns.svc
  MYSQL_PORT: '3306'
  MYSQL_USER: admin
  MYSQL_PASSWORD: admin
```

Run the job template:
```
oc new-app \
-f templates/openshift/backup-job-template.yaml \
-p 'COMPONENT=mysql' \
-p 'COMPONENT_SECRET_NAME=sample-mysql-secret' \
-p 'BACKEND_SECRET_NAME=sample-s3-secret' \
-p 'ENCRYPTION_SECRET_NAME=sample-gpg-secret'\
 -p 'IMAGE=quay.io/integreatly/backup-container:latest' \
-p 'NAME=mysql-backup'
```
It should trigger a kubernetes job, backup all databases for that user, encrypt all those files and send to a remote bucket in s3.