### PR TITLE
[wip] Allow backupjob sa to read secrets only from the default ns

### DIFF
--- a/templates/openshift/rbac/role-binding.yaml
+++ b/templates/openshift/rbac/role-binding.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: authorization.openshift.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -8,3 +9,50 @@ subjects:
   - kind: ServiceAccount
     namespace: backup
     name: backupjob
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: backupjob-read-secrets
+  namespace: default
+subjects:
+  - kind: ServiceAccount
+    name: backupjob
+    namespace: 3scale
+  - kind: ServiceAccount
+    name: backupjob
+    namespace: apicurito
+  - kind: ServiceAccount
+    name: backupjob
+    namespace: codeready
+  - kind: ServiceAccount
+    name: backupjob
+    namespace: enmasse
+  - kind: ServiceAccount
+    name: backupjob
+    namespace: fuse
+  - kind: ServiceAccount
+    name: backupjob
+    namespace: gitea
+  - kind: ServiceAccount
+    name: backupjob
+    namespace: launcher
+  - kind: ServiceAccount
+    name: backupjob
+    namespace: managed-service-broker
+  - kind: ServiceAccount
+    name: backupjob
+    namespace: middleware-monitoring
+  - kind: ServiceAccount
+    name: backupjob
+    namespace: nexus
+  - kind: ServiceAccount
+    name: backupjob
+    namespace: sso
+  - kind: ServiceAccount
+    name: backupjob
+    namespace: webapp
+roleRef:
+  kind: Role
+  name: backupjob-secret-reader

--- a/templates/openshift/rbac/role.yaml
+++ b/templates/openshift/rbac/role.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: authorization.openshift.io/v1
 kind: ClusterRole
 metadata:
@@ -7,6 +8,18 @@ rules:
       - ""
     resources:
       - configmaps
-      - secrets
     verbs:
       - '*'
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: backupjob-secret-reader
+  namespace: default
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs: ['get', 'list']


### PR DESCRIPTION
The current cluster role and cluster role binding allows the service account `backupjob` to access secrets from any namespaces. This should be changed to only allow the `backupjob` service account to access the secrets in the `default` namespace where the AWS credentials will be stored.

The following changes includes:
- Addition of the role `backupjob-secret-reader` which allows a `get` and `list` of the secrets resource
- Addition of the role binding `backupjob-read-secrets` which allows the service accounts `backupjob` created in the middleware namespaces to access the secrets in the default namespace.

## Verification Steps
**Initial Setup**: 
- Create the role and rolebindings
  ```
    oc create -f templates/openshift/rbac/role.yaml
    oc create -f templates/openshift/rbac/role-binding.yaml
  ```

**Using a middleware service namespace**
- Select a middleware service namespace (i.e. `oc project gitea`)
- Create a blank secret and a service account
  ```
    oc create -f templates/openshift/rbac/service-account.yaml
    oc create -f templates/openshift/sample-config/blank-secret.yaml
  ```
- Create a backup job which gets secrets from the `default` namespace
  ```
    oc new-app \
    -f templates/openshift/backup-job-template.yaml \
    -p 'COMPONENT=getsecretdefaultns' \
    -p 'COMPONENT_SECRET_NAME=sample-no-encryption-secret' \
    -p 'BACKEND_SECRET_NAME=sample-no-encryption-secret' \
    -p 'ENCRYPTION_SECRET_NAME=sample-no-encryption-secret'\
    -p 'IMAGE=quay.io/jameelb/backup-container:INTLY-1165' \
    -p 'NAME=test-backup' \
    -p 'DEBUG=y'
  ```
    - Look at the logs `oc logs -f <pod-name>`
    - Ensure the logs shows the list of secrets within the `default` namespace.
- Create a backup job which gets secrets from another namespace
  ```
    oc new-app \
    -f templates/openshift/backup-job-template.yaml \
    -p 'COMPONENT=getsecretotherns' \
    -p 'COMPONENT_SECRET_NAME=sample-no-encryption-secret' \
    -p 'BACKEND_SECRET_NAME=sample-no-encryption-secret' \
    -p 'ENCRYPTION_SECRET_NAME=sample-no-encryption-secret'\
    -p 'IMAGE=quay.io/jameelb/backup-container:INTLY-1165' \
    -p 'NAME=test-backup' \
    -p 'DEBUG=y'
  ```
    - Ensure that the backupjob created is unable to get secrets from the namespace.

Using a non-middleware service namespace
- Select a non-middleware service namespace (i.e. `oc project test`)
- Follow the same steps used above.
- Ensure that the backup job is unable to get secrets from the default and any other namespaces.