### PR TITLE
Use the single-transaction option with MySQL database dumps

### DIFF
--- a/image/tools/lib/component/mysql.sh
+++ b/image/tools/lib/component/mysql.sh
@@ -3,7 +3,7 @@ function component_dump_data {
     databases=$(mysql -h$MYSQL_HOST -u$MYSQL_USER  -p$MYSQL_PASSWORD -e 'SHOW DATABASES' | tail -n+2 | grep -v information_schema)
     for database in $databases; do
         ts=$(date '+%H:%M:%S')
-        mysqldump -h$MYSQL_HOST -u$MYSQL_USER -p$MYSQL_PASSWORD -R $database | gzip > $dest/archives/$database-$ts.dump.gz
+        mysqldump --single-transaction -h$MYSQL_HOST -u$MYSQL_USER -p$MYSQL_PASSWORD -R $database | gzip > $dest/archives/$database-$ts.dump.gz
         rc=$?
         if [ $rc -ne 0 ]; then
             echo "==> Dump $database: FAILED"


### PR DESCRIPTION
Without this flag being set we can hit issues with certain
databases like:

SELECT, LOCK TABLES command denied to user u for table t when using LOCK TABLES

This either requires more permissions to be given to the user, or
for this flag to be set. So this is the least intrusive option.