### PR TITLE
INTLY-1000 - add redis backup component

### DIFF
--- a/image/tools/entrypoint.sh
+++ b/image/tools/entrypoint.sh
@@ -38,10 +38,11 @@ DATESTAMP=$(date '+%Y/%m/%d')
 DEST=/tmp/intly
 ARCHIVES_DEST=$DEST/archives
 mkdir -p $DEST $ARCHIVES_DEST
-export HOME=$DEST
 
 component_dump_data $DEST
 echo '==> Component data dump completed'
+
+export HOME=$DEST
 if [[ "$encryption_engine" ]]; then
     encrypt_prepare $DEST
     encrypted_files="$(encrypt_archive $ARCHIVES_DEST)"

--- a/image/tools/lib/component/3scale-redis.sh
+++ b/image/tools/lib/component/3scale-redis.sh
@@ -1,0 +1,16 @@
+function component_dump_data {
+    dest_file="$1/archives/dump.rdb"
+    dumb_rdb_path="/var/lib/redis/data/dump.rdb"
+
+    oc projects
+    redis_pod_name=$(oc get pods -l deploymentConfig=backend-redis -o name -n 3scale | sed -e 's/^pod\///')
+    copy_output=$(oc cp 3scale/${redis_pod_name}:${dumb_rdb_path} ${dest_file})
+    echo ${copy_output}
+    
+    # check if rdb file was rewritten during oc cp, and copy it again if it was
+    if [[ $copy_output == *"file changed as we read it"* ]]; then
+        sleep 10s #wait until rdb rewrite finished
+        echo "dumb.rdb has been overwritten during copying, executing 'oc cp' again"
+        oc cp 3scale/${redis_pod_name}:${dumb_rdb_path} ${dest_file}
+    fi
+}

--- a/templates/openshift/rbac/role.yaml
+++ b/templates/openshift/rbac/role.yaml
@@ -6,3 +6,9 @@ rules:
   - apiGroups: ['*']
     resources: ['*']
     verbs: ['get', 'list']
+  - apiGroups:
+    - ['']
+    resources:
+      - ['pods/exec']
+    verbs:
+      - ['create']


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/INTLY-1000 / https://issues.jboss.org/browse/INTLY-1196

I added Redis component for 3Scale and did small tweaks to entrypoint.sh (I'll explain those "inline").


You will need to create all the secrets and roles from templates/openshift/* folders.
Then you can create a job like this:
```oc new-app -f templates/openshift/backup-job-template.yaml -p 'COMPONENT=redis' -p 'BACKEND_SECRET_NAME=sample-s3-secret'  -p 'ENCRYPTION_SECRET_NAME=sample-gpg-secret' -p 'IMAGE=omatskiv/backup-container:dev' -p 'NAME=redis-backupjob' -p 'COMPONENT_SECRET_NAME=sample-mysql-secret'```

OR

Test locally and verify that dumbp.rdb file was copied to /tmp/intly/ folder.
Login with oc and run:
```./image/tools/entrypoint.sh -c redis -e ""```