### PR TITLE
[WIP] update mysql backup to use secrets from default namespace

### DIFF
--- a/image/tools/lib/component/mysql.sh
+++ b/image/tools/lib/component/mysql.sh
@@ -1,11 +1,28 @@
+function get_mysql_host {
+    echo "`oc get secret ${COMPONENT_SECRET_NAME} -n default -o jsonpath={.data.MYSQL_HOST} | base64 --decode`"
+}
+
+function get_mysql_user {
+    echo "`oc get secret ${COMPONENT_SECRET_NAME} -n default -o jsonpath={.data.MYSQL_USER} | base64 --decode`"
+}
+
+function get_mysql_password {
+    echo "`oc get secret ${COMPONENT_SECRET_NAME} -n default -o jsonpath={.data.MYSQL_PASSWORD} | base64 --decode`"
+}
+
 function component_dump_data {
-    dest=$1
-    databases=$(mysql -h$MYSQL_HOST -u$MYSQL_USER  -p$MYSQL_PASSWORD -e 'SHOW DATABASES' | tail -n+2 | grep -v information_schema)
-    for database in $databases; do
-        ts=$(date '+%H:%M:%S')
-        mysqldump --single-transaction -h$MYSQL_HOST -u$MYSQL_USER -p$MYSQL_PASSWORD -R $database | gzip > $dest/archives/$database-$ts.dump.gz
-        rc=$?
-        if [ $rc -ne 0 ]; then
+    local dest=$1
+    local MYSQL_HOST=$(get_mysql_host)
+    local MYSQL_USER=$(get_mysql_user)
+    local MYSQL_PASSWORD=$(get_mysql_password)
+
+    databases=$(mysql -h${MYSQL_HOST} -u${MYSQL_USER}  -p${MYSQL_PASSWORD} -e 'SHOW DATABASES' | tail -n+2 | grep -v information_schema)
+
+    for database in ${databases}; do
+        local ts=$(date '+%H:%M:%S')
+        mysqldump --single-transaction -h${MYSQL_HOST} -u${MYSQL_USER} -p${MYSQL_PASSWORD} -R ${database} | gzip > ${dest}/archives/${database}-${ts}.dump.gz
+        local rc=$?
+        if [[ ${rc} -ne 0 ]]; then
             echo "==> Dump $database: FAILED"
             exit 1
         fi

--- a/templates/openshift/backup-cronjob-template.yaml
+++ b/templates/openshift/backup-cronjob-template.yaml
@@ -37,12 +37,11 @@ objects:
                     - "${DEBUG}"
                   env:
                     - name: BACKEND_SECRET_NAME
-                      value: ${BACKEND_SECRET_NAME}
+                      value: "${BACKEND_SECRET_NAME}"
                     - name: ENCRYPTION_SECRET_NAME
-                      value: ${ENCRYPTION_SECRET_NAME}
-                  envFrom:
-                    - secretRef:
-                        name: "${COMPONENT_SECRET_NAME}"
+                      value: "${ENCRYPTION_SECRET_NAME}"
+                    - name: COMPONENT_SECRET_NAME
+                      value: "${COMPONENT_SECRET_NAME}"
               restartPolicy: Never
 parameters:
   - name: NAME
@@ -59,6 +58,7 @@ parameters:
   - name: COMPONENT_SECRET_NAME
     description: Component secret name to create environment variables from
     required: true
+    value: dummy
   - name: BACKEND_SECRET_NAME
     description: Backend secret name to create environment variables from
     required: true

--- a/templates/openshift/backup-job-template.yaml
+++ b/templates/openshift/backup-job-template.yaml
@@ -36,12 +36,11 @@ objects:
                 - "${DEBUG}"
               env:
                 - name: BACKEND_SECRET_NAME
-                  value: ${BACKEND_SECRET_NAME}
+                  value: "${BACKEND_SECRET_NAME}"
                 - name: ENCRYPTION_SECRET_NAME
-                  value: ${ENCRYPTION_SECRET_NAME}
-              envFrom:
-                - secretRef:
-                    name: "${COMPONENT_SECRET_NAME}"
+                  value: "${ENCRYPTION_SECRET_NAME}"
+                - name: COMPONENT_SECRET_NAME
+                  value: "${COMPONENT_SECRET_NAME}"
           restartPolicy: Never
 parameters:
   - name: NAME


### PR DESCRIPTION
This updates the mysql script to no longer depend on a mounted component secret but instead reference the credentials secret from the default namespace using oc. The idea is that all secrets will be placed in the default namespace.

@aidenkeating this would also affect your current installer PR to set up the 3scale mysql backup.

TODO: before this can be merged the other scripts also have to be updated. I'll can add those changes to this PR.