### PR TITLE
Fix the YAML for the included role to be a valid ClusterRole

### DIFF
--- a/templates/openshift/rbac/role.yaml
+++ b/templates/openshift/rbac/role.yaml
@@ -6,9 +6,6 @@ rules:
   - apiGroups: ['*']
     resources: ['*']
     verbs: ['get', 'list']
-  - apiGroups:
-    - ['']
-    resources:
-      - ['pods/exec']
-    verbs:
-      - ['create']
+  - apiGroups: ['']
+    resources: ['pods/exec']
+    verbs: ['create']


### PR DESCRIPTION
Currently we have a role.yaml file, however it doesn't contain YAML
that can be used with `oc create`. This is because we are making
the lists of apiGroups and reources contain sub-lists instead of
being a list of strings.

Verification:
- Ensure running oc create with the role.yaml in 90325cc fails
- Ensure running oc create with the role in this commit succeeds
