### PR TITLE
Retrieve POSTGRES_SUPERUSER from postgres secret

### DIFF
--- a/image/tools/lib/component/postgres.sh
+++ b/image/tools/lib/component/postgres.sh
@@ -16,12 +16,18 @@ function get_postgres_database {
   echo "`oc get secret ${COMPONENT_SECRET_NAME} -n default -o jsonpath={.data.POSTGRES_DATABASE} | base64 --decode`"
 }
 
+function get_postgres_superuser {
+  echo "`oc get secret ${COMPONENT_SECRET_NAME} -n default -o jsonpath={.data.POSTGRES_SUPERUSER} | base64 --decode`"
+}
+
 function component_dump_data {
   local dest=$1
   local POSTGRES_USERNAME=$(get_postgres_username)
   local POSTGRES_PASSWORD=$(get_postgres_password)
   local POSTGRES_HOST=$(get_postgres_host)
   local POSTGRES_DATABASE=$(get_postgres_database)
+  local POSTGRES_SUPERUSER=$(get_postgres_superuser)
+
   echo "*:5432:*:${POSTGRES_USERNAME}:${POSTGRES_PASSWORD}" > ~/.pgpass
   chmod 0600 ~/.pgpass
   ts=$(date '+%H:%M:%S')


### PR DESCRIPTION
`POSTGRES_SUPERUSER` was missed when how we retrieve the vars was changed.

`POSTGRES_SUPERUSER=false`
![3-file what](https://user-images.githubusercontent.com/22113654/53795102-2a748880-3f29-11e9-89b9-aa0f15955f44.png)
`POSTGRES_SUPERUSER=true`
![dump_all](https://user-images.githubusercontent.com/22113654/53795122-352f1d80-3f29-11e9-9aa0-ebc8d5888acc.png)
