### PR TITLE
improvements to make managing resources easier

### DIFF
--- a/image/tools/lib/component/resources.sh
+++ b/image/tools/lib/component/resources.sh
@@ -29,8 +29,33 @@ function backup_resource {
     check_resource ${type} ${ns}
     if [[ $? -eq 0 ]]; then
         echo "==> backing up $type in $ns"
-        oc get ${type} -n ${ns} -o yaml --export | gzip > ${dest}/archives/intly_${type}-${ns}-${TS}.yaml.gz
+        oc get ${type} -n ${ns} -o yaml --export | gzip > ${dest}/archives/${ns}-${type}.yaml.gz
     fi
+}
+
+# Backs up a namespace
+function backup_namespace {
+    local ns=$1
+    local dest=$2
+    echo "==> backing up namespace $ns"
+    oc get namespace ${ns} -o yaml --export | gzip > ${dest}/archives/${ns}-namespace.yaml.gz
+}
+
+# Backs up all service accounts in a namespace but excludes the
+# system ones
+function backup_service_accounts {
+    local ns=$1
+    local dest=$2
+    echo "==> backing up service accounts in $ns"
+    oc get serviceaccounts -n ${ns} --field-selector='metadata.name!=builder,metadata.name!=deployer,metadata.name!=default' -o yaml --export | gzip > ${dest}/archives/${ns}-sa.yaml.gz
+}
+
+# Backs up all rolebindings in a namespace but excludes the system ones
+function backup_role_bindings {
+    local ns=$1
+    local dest=$2
+    echo "==> backing up role bindings in $ns"
+    oc get rolebindings -n ${ns} --field-selector='metadata.name!=system:deployers,metadata.name!=system:image-builders,metadata.name!=system:image-pullers' -o yaml --export | gzip > ${dest}/archives/${ns}-rb.yaml.gz
 }
 
 # Backs up a cluster level resource
@@ -38,15 +63,15 @@ function backup_cluster_resource {
     local type=$1
     local dest=$2
     echo "==> backing up cluster resource $type"
-    oc get ${type} -o yaml --export | gzip > ${dest}/archives/intly_${type}-${TS}.yaml.gz
+    oc get ${type} -o yaml --export | gzip > ${dest}/archives/${type}.yaml.gz
 }
 
 # Archive all files
 function archive_files {
     dest=$1
     cd ${dest}/archives
-    tar -czf resources_${TS}.tar.gz .
-    rm -f intly_*
+    tar --exclude='*.tar.gz' -czf resources_${TS}.tar.gz .
+    rm -f *.yaml.gz
 }
 
 # Entry point
@@ -61,11 +86,8 @@ function component_dump_data {
         backup_resource services ${ns} ${dest}
         backup_resource routes ${ns} ${dest}
         backup_resource deployments ${ns} ${dest}
-        backup_resource namespaces ${ns} ${dest}
         backup_resource roles ${ns} ${dest}
-        backup_resource rolebindings ${ns} ${dest}
         backup_resource webapps ${ns} ${dest}
-        backup_resource serviceaccounts ${ns} ${dest}
         backup_resource keycloaks ${ns} ${dest}
         backup_resource keycloakrealms ${ns} ${dest}
         backup_resource alertmanagers ${ns} ${dest}
@@ -76,6 +98,9 @@ function component_dump_data {
         backup_resource prometheuses ${ns} ${dest}
         backup_resource servicemonitors ${ns} ${dest}
         backup_resource syndesises ${ns} ${dest}
+        backup_service_accounts ${ns} ${dest}
+        backup_role_bindings ${ns} ${dest}
+        backup_namespace ${ns} ${dest}
     done
 
     echo "==> processing cluster resources"


### PR DESCRIPTION
A few improvements to the resources backup:

* The filename pattern is now `<namespace-resource>.yaml`, e.g. `enmasse-deployments.yaml`. This makes it easier to deal with a single namespace by copying all the files to a subdir, e.g. `cp enmasse-* ./restore-enmasse` 
* No more timestamps on the archived files, onyl on the archive itself
* Exclude system serviceaccounts and rolebindings in the backup because they are expected to be there and caused errors when restoring them.
* There is now a namespace file for every namespace just like for the other resources, e.g. `3scale-namespace.yaml`. It only contains this one namespace.
* Fixed a bug where the archive itself was included in the archive (this caused the tar warning about a file being modified while being written to).