### PR TITLE
allow component secrets outside of default namespace

### DIFF
--- a/image/tools/entrypoint.sh
+++ b/image/tools/entrypoint.sh
@@ -2,14 +2,18 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 component=''
+component_secret_namespace='default'
 archive_backend='s3'
 encryption_engine='gpg'
 debug=''
 
-while getopts "c:b:e:d:" opt; do
+while getopts "c:n:b:e:d:" opt; do
     case "$opt" in
     c)
         component="$OPTARG"
+        ;;
+    n)
+        component_secret_namespace="$OPTARG"
         ;;
     b)
         archive_backend="$OPTARG"

--- a/image/tools/lib/component/postgres.sh
+++ b/image/tools/lib/component/postgres.sh
@@ -1,23 +1,23 @@
 #!/usr/bin/env bash
 
 function get_postgres_username {
-  echo "`oc get secret ${COMPONENT_SECRET_NAME} -n default -o jsonpath={.data.POSTGRES_USERNAME} | base64 --decode`"
+  echo "`oc get secret ${COMPONENT_SECRET_NAME} -n ${component_secret_namespace} -o jsonpath={.data.POSTGRES_USERNAME} | base64 --decode`"
 }
 
 function get_postgres_password {
-  echo "`oc get secret ${COMPONENT_SECRET_NAME} -n default -o jsonpath={.data.POSTGRES_PASSWORD} | base64 --decode`"
+  echo "`oc get secret ${COMPONENT_SECRET_NAME} -n ${component_secret_namespace} -o jsonpath={.data.POSTGRES_PASSWORD} | base64 --decode`"
 }
 
 function get_postgres_host {
-  echo "`oc get secret ${COMPONENT_SECRET_NAME} -n default -o jsonpath={.data.POSTGRES_HOST} | base64 --decode`"
+  echo "`oc get secret ${COMPONENT_SECRET_NAME} -n ${component_secret_namespace} -o jsonpath={.data.POSTGRES_HOST} | base64 --decode`"
 }
 
 function get_postgres_database {
-  echo "`oc get secret ${COMPONENT_SECRET_NAME} -n default -o jsonpath={.data.POSTGRES_DATABASE} | base64 --decode`"
+  echo "`oc get secret ${COMPONENT_SECRET_NAME} -n ${component_secret_namespace} -o jsonpath={.data.POSTGRES_DATABASE} | base64 --decode`"
 }
 
 function get_postgres_superuser {
-  echo "`oc get secret ${COMPONENT_SECRET_NAME} -n default -o jsonpath={.data.POSTGRES_SUPERUSER} | base64 --decode`"
+  echo "`oc get secret ${COMPONENT_SECRET_NAME} -n ${component_secret_namespace} -o jsonpath={.data.POSTGRES_SUPERUSER} | base64 --decode`"
 }
 
 function component_dump_data {

--- a/templates/openshift/backup-job-template.yaml
+++ b/templates/openshift/backup-job-template.yaml
@@ -28,6 +28,8 @@ objects:
                 - "/opt/intly/tools/entrypoint.sh"
                 - "-c"
                 - "${COMPONENT}"
+                - "-n"
+                - "${COMPONENT_SECRET_NAMESPACE}"
                 - '-b'
                 - "${BACKEND}"
                 - "-e"
@@ -57,6 +59,9 @@ parameters:
     value: gpg
   - name: COMPONENT_SECRET_NAME
     description: Component secret name to create environment variables from
+  - name: COMPONENT_SECRET_NAMESPACE
+    description: If the component secret is not in default, put it's namespace here
+    value: default
     required: true
     value: dummy
   - name: BACKEND_SECRET_NAME


### PR DESCRIPTION
keycloak needs to store the component credentials in  the sso namespace as it is created by the keycloak operator.

This allows the backup job to tell the image what namespace the credentials will be in, but defaults to default.