### PR TITLE
Make encryption optional in Job template

### DIFF
--- a/templates/openshift/backup-job-template.yaml
+++ b/templates/openshift/backup-job-template.yaml
@@ -54,7 +54,6 @@ parameters:
     value: s3
   - name: ENCRYPTION
     description: Encryption engine to encrypt component archive before uploading it
-    value: gpg
   - name: COMPONENT_SECRET_NAME
     description: Component secret name to create environment variables from
     required: true


### PR DESCRIPTION
It's already optional in CronJob, and this change aligns template with our SOP. 