### PR TITLE
check glob before uploading

### DIFF
--- a/image/tools/entrypoint.sh
+++ b/image/tools/entrypoint.sh
@@ -66,7 +66,6 @@ else
     encrypted_files="$ARCHIVES_DEST/*"
 fi
 upload_archive "${encrypted_files}" $DATESTAMP backups/$PRODUCT_NAME/$component
-echo '==> Archive upload completed'
 
 echo "[$DATESTAMP] Backup completed"
 

--- a/image/tools/lib/backend/s3.sh
+++ b/image/tools/lib/backend/s3.sh
@@ -35,11 +35,16 @@ function upload_archive {
     local AWS_SECRET_ACCESS_KEY="$(get_s3_access_key)"
 
     for fname in ${file_list}; do
-        s3cmd put --access_key ${AWS_ACCESS_KEY_ID} --secret_key ${AWS_SECRET_ACCESS_KEY} --progress ${fname} "s3://$AWS_S3_BUCKET_NAME/$bucket_folder/$datestamp/$(basename ${fname})"
-        rc=$?
-        if [[ ${rc} -ne 0 ]]; then
-            echo "==> Upload $fname: FAILED"
-            exit 1
+        ls ${fname}
+
+        # ls will exit with 1 if the glob does not expand to any files
+        if [[ $? -eq 0 ]]; then
+            s3cmd put --access_key ${AWS_ACCESS_KEY_ID} --secret_key ${AWS_SECRET_ACCESS_KEY} --progress ${fname} "s3://$AWS_S3_BUCKET_NAME/$bucket_folder/$datestamp/$(basename ${fname})"
+            rc=$?
+            if [[ ${rc} -ne 0 ]]; then
+                echo "==> Upload $fname: FAILED"
+                exit 1
+            fi
         fi
     done
 }

--- a/image/tools/lib/backend/s3.sh
+++ b/image/tools/lib/backend/s3.sh
@@ -45,6 +45,9 @@ function upload_archive {
                 echo "==> Upload $fname: FAILED"
                 exit 1
             fi
+            echo "==> Upload ${fname} completed"
+        else
+            echo "==> No backups in ${fname} to upload"
         fi
     done
 }

--- a/image/tools/lib/component/enmasse_pv.sh
+++ b/image/tools/lib/component/enmasse_pv.sh
@@ -26,7 +26,12 @@ function component_dump_data {
         dump_pod_data ${pod} ${dump_dest}
     done
 
-    local ts=$(date '+%H:%M:%S')
-    tar -zcvf "$archive_path/enmasse-pv-data-${ts}.tar.gz" -C $dump_dest .
-    rm -rf $dump_dest
+    ls ${dump_dest}/*
+    if [[ $? -eq 0 ]]; then
+        local ts=$(date '+%H:%M:%S')
+        tar -zcvf "$archive_path/enmasse-pv-data-${ts}.tar.gz" -C $dump_dest .
+        rm -rf $dump_dest
+    else
+        echo "==> no enmasse broker data to backup"
+    fi
 }


### PR DESCRIPTION
Make sure an archive exists before attempting to upload it. Otherwise this causes the backup container to fail. This is achieved by running `ls <glob>` before the upload. `ls` returns exit code 1 when the glob cannot be expanded.

Verification:

* Run the codeready backup without and workspaces created: the pod should execute successfully
* Run the codeready backup with workspaces created: the pod should also execute successfully and upload the archive.

To verify the enmasse archives:
* Run the enmasse backup job on a standard installation and check the logs of the backup: it should not upload anything (unless there are already broker pods).
* Now go to the service catalog and select AMQ Online (brokered)
* Add this to your enmasse namespace under the name `broker`: this will provision a new broker pod
* Open the broker pods terminal and create some file in `/var/run/artemis` (e.g. `echo "test" > /var/run/artemis/test.txt`)
* Run the backup again and check the logs
* This time an archive should be produced and uploaded