### PR TITLE
INTLY-1100 Add monitoring label and concurrency policy

### DIFF
--- a/templates/openshift/backup-cronjob-template.yaml
+++ b/templates/openshift/backup-cronjob-template.yaml
@@ -10,14 +10,18 @@ objects:
     kind: CronJob
     metadata:
       name: ${NAME}
+      labels:
+        monitoring-key: middleware
     spec:
       schedule: ${CRON_SCHEDULE}
+      concurrencyPolicy: ${CONCURRENCY_POLICY}
       jobTemplate:
         spec:
           template:
             metadata:
               name: ${NAME}
               labels:
+                monitoring-key: middleware
                 cronjob-name: ${NAME}
             spec:
               serviceAccountName: "${SERVICEACCOUNT}"
@@ -83,3 +87,6 @@ parameters:
     value: backupjob
   - name: DEBUG
     description: "Debug flag to sleep the job pod after its execution"
+  - name: CONCURRENCY_POLICY
+    description: The concurrency policy of the CronJob
+    value: Forbid

--- a/templates/openshift/backup-job-template.yaml
+++ b/templates/openshift/backup-job-template.yaml
@@ -10,6 +10,8 @@ objects:
     kind: Job
     metadata:
       name: ${NAME}
+      labels:
+        monitoring-key: middleware
     spec:
       parallelism: 1
       completions: 1


### PR DESCRIPTION
Allow the concurrency policy to be overridden and default the value
to Forbid. The reasoning for this is to prevent multiple occurrences
of the same Job to run at the same time.

Add monitoring labels to the CronJob and the Jobs that it creates
so that monitoring alerts can reference that when referring to
all Integreatly CronJobs instead of just having a static list.

Verification:
- Modify the cron schedule in the CronJob template to be something
like `*/1 * * * *`, to run once per minute.
- Do an `oc create` on the template.
- Ensure that the created CronJob has the `concurrencyPolicy` of
`Forbid`.
- Ensure that the created CronJob has a label with the name
`monitoring-key` and the value `middleware`.
- Ensure that a Job created by the CronJob has a label with the
name `monitoring-key` and the value `middleware`.