### PR TITLE
INTLY-1287: Backup additional resources and default NS

### DIFF
--- a/image/tools/lib/component/resources.sh
+++ b/image/tools/lib/component/resources.sh
@@ -90,7 +90,7 @@ function component_dump_data {
     local dest=$1
     local namespaces=$(get_middleware_namespaces)
 
-    for ns in ${namespaces}; do
+    for ns in ${namespaces} "default"; do
         echo "==> processing namespace $ns"
         backup_resource secrets ${ns} ${dest}
         backup_resource configmaps ${ns} ${dest}
@@ -117,6 +117,15 @@ function component_dump_data {
         backup_resource addressspaces ${ns} ${dest}
         backup_resource addressspaceschemas ${ns} ${dest}
         backup_resource messagingusers ${ns} ${dest} 'y'
+        backup_resource limitranges ${ns} ${dest}
+        backup_resource persistentvolumeclaims ${ns} ${dest}
+        backup_resource statefulsets ${ns} ${dest}
+        backup_resource buildconfigs ${ns} ${dest}
+        backup_resource builds ${ns} ${dest}
+        backup_resource imagestreamtag ${ns} ${dest}
+        backup_resource prometheusrules ${ns} ${dest}
+        backup_resource deploymentconfigs ${ns} ${dest}
+
         backup_service_accounts ${ns} ${dest}
         backup_role_bindings ${ns} ${dest}
         backup_namespace ${ns} ${dest}
@@ -129,6 +138,8 @@ function component_dump_data {
     backup_cluster_resource clusterservicebrokers ${dest}
     backup_cluster_resource clusterroles ${dest}
     backup_cluster_resource clusterrolebindings ${dest}
+    backup_cluster_resource cronjobs ${dest}
+    backup_cluster_resource customresourcedefinitions ${dest}
 
     # Create a single archive including all files
     archive_files ${dest}


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/INTLY-1287
I added backup of default namespace and some resources which we were not backing up.

## Verification:
Review the resource types that I added.
Review a diff of what we are still (not)backing up: https://www.diffchecker.com/aGVzHfpF (duplicates on the left are due to different "packages", but I stripped those for the diff).
If everything makes sense, test the backup:
```
oc login
mkdir -p /tmp/intly/ && ln -s ~/.kube/ /tmp/intly/.kube
./image/tools/entrypoint.sh -c resources
```