### PR TITLE
INTLY-1307: Fix tar command in resources backup

### DIFF
--- a/image/tools/lib/component/resources.sh
+++ b/image/tools/lib/component/resources.sh
@@ -81,7 +81,7 @@ function backup_cluster_resource {
 function archive_files {
     dest=$1
     cd ${dest}/archives
-    tar --exclude='*.tar.gz' -czf resources_${TS}.tar.gz .
+    tar --exclude='*.tar.gz' --force-local -czf resources_${TS}.tar.gz .
     rm -f *.yaml.gz
 }
 


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/INTLY-1307

Fixes `tar (child): Cannot connect to resources_15: resolve failed` error.
Solution explanation: https://unix.stackexchange.com/a/13381