### PR TITLE
INTLY-1343: Change timestamp format to avoid issues with tar

### DIFF
--- a/image/tools/lib/component/3scale-redis.sh
+++ b/image/tools/lib/component/3scale-redis.sh
@@ -1,5 +1,5 @@
 function component_dump_data {
-    local ts=$(date '+%H:%M:%S')
+    local ts=$(date '+%H_%M_%S')
     dest_file="$1/archives/dump-${ts}.rdb"
     dump_rdb_path="/var/lib/redis/data/dump.rdb"
 

--- a/image/tools/lib/component/codeready_pv.sh
+++ b/image/tools/lib/component/codeready_pv.sh
@@ -18,7 +18,7 @@ function component_dump_data {
         dump_dest="/tmp/codeready-data"
         mkdir -p $dump_dest
         for i in $workspace_pods; do dump_pod_data $i $dump_dest; done
-        local ts=$(date '+%H:%M:%S')
+        local ts=$(date '+%H_%M_%S')
         tar -zcvf "$archive_path/codeready-pv-data-${ts}.tar.gz" -C $dump_dest .
         rm -rf $dump_dest
     fi

--- a/image/tools/lib/component/enmasse_pv.sh
+++ b/image/tools/lib/component/enmasse_pv.sh
@@ -28,7 +28,7 @@ function component_dump_data {
 
     ls ${dump_dest}/*
     if [[ $? -eq 0 ]]; then
-        local ts=$(date '+%H:%M:%S')
+        local ts=$(date '+%H_%M_%S')
         tar -zcvf "$archive_path/enmasse-pv-data-${ts}.tar.gz" -C $dump_dest .
         rm -rf $dump_dest
     else

--- a/image/tools/lib/component/mysql.sh
+++ b/image/tools/lib/component/mysql.sh
@@ -35,7 +35,7 @@ function component_dump_data {
     databases=$(mysql -h${MYSQL_HOST} -u${MYSQL_USER}  -p${MYSQL_PASSWORD} -e 'SHOW DATABASES' | tail -n+2 | grep -v information_schema)
 
     for database in ${databases}; do
-        local ts=$(date '+%H:%M:%S')
+        local ts=$(date '+%H_%M_%S')
         mysqldump --single-transaction -h${MYSQL_HOST} -u${MYSQL_USER} -p${MYSQL_PASSWORD} -R ${database} | gzip > ${dest}/archives/${database}-${ts}.dump.gz
         local rc=$?
         if [[ ${rc} -ne 0 ]]; then

--- a/image/tools/lib/component/postgres.sh
+++ b/image/tools/lib/component/postgres.sh
@@ -30,7 +30,7 @@ function component_dump_data {
 
   echo "*:5432:*:${POSTGRES_USERNAME}:${POSTGRES_PASSWORD}" > ~/.pgpass
   chmod 0600 ~/.pgpass
-  ts=$(date '+%H:%M:%S')
+  ts=$(date '+%H_%M_%S')
   export PGPASSFILE=~/.pgpass
   namespace=${POSTGRES_HOST#*.}
   namespace=${namespace%.*}

--- a/image/tools/lib/component/resources.sh
+++ b/image/tools/lib/component/resources.sh
@@ -1,4 +1,4 @@
-TS=$(date '+%H:%M:%S')
+TS=$(date '+%H_%M_%S')
 
 function get_middleware_namespaces {
     echo "`oc get namespaces --selector='integreatly-middleware-service=true' -o jsonpath='{.items[*].metadata.name}'`"


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/INTLY-1343

This will prevent errors during restoration that look like this:
```
tar (child): Cannot connect to resources_15: resolve failed
```
We already seen this problem in the backup scripts, fix was a bit different - #32 
Changing the format is probably more pragmatic solution, and won't require any additional params when doing unpacking during restoration.