### PR TITLE
INTLY-1493 - Add parameter for namespace prefix

### DIFF
--- a/image/tools/lib/component/3scale-redis.sh
+++ b/image/tools/lib/component/3scale-redis.sh
@@ -4,6 +4,6 @@ function component_dump_data {
     dump_rdb_path="/var/lib/redis/data/dump.rdb"
 
     oc projects
-    redis_pod_name=$(oc get pods -l deploymentConfig=backend-redis -o name -n 3scale | sed -e 's/^pod\///')
-    cp_pod_data "3scale/${redis_pod_name}:${dump_rdb_path}" "${dest_file}"
+    redis_pod_name=$(oc get pods -l deploymentConfig=backend-redis -o name -n ${PRODUCT_NAMESPACE_PREFIX}3scale | sed -e 's/^pod\///')
+    cp_pod_data "${PRODUCT_NAMESPACE_PREFIX}3scale/${redis_pod_name}:${dump_rdb_path}" "${dest_file}"
 }

--- a/image/tools/lib/component/codeready_pv.sh
+++ b/image/tools/lib/component/codeready_pv.sh
@@ -4,11 +4,11 @@ function dump_pod_data {
     workspace_pod_name=$1
     dump_dest=$2
     workspace_id=$(echo ${workspace_pod_name} | awk -F"." '{ print $1}')
-    cp_pod_data "codeready/${workspace_pod_name}:/projects" "${dump_dest}/${workspace_id}"
+    cp_pod_data "${PRODUCT_NAMESPACE_PREFIX}codeready/${workspace_pod_name}:/projects" "${dump_dest}/${workspace_id}"
 }
 
 function component_dump_data {
-    workspace_pods=$(oc get pods -n codeready | grep workspace | awk '{print $1}')
+    workspace_pods=$(oc get pods -n ${PRODUCT_NAMESPACE_PREFIX}codeready | grep workspace | awk '{print $1}')
 
     if [ ${#workspace_pods} = 0 ]
     then

--- a/image/tools/lib/component/enmasse_pv.sh
+++ b/image/tools/lib/component/enmasse_pv.sh
@@ -2,7 +2,7 @@
 
 # Brokered pods have a storage PV attached. They are labelled with role=broker
 function get_broker_pods {
-    echo "`oc get pods --selector='role=broker' -n enmasse -o jsonpath='{.items[*].metadata.name}'`"
+    echo "`oc get pods --selector='role=broker' -n ${PRODUCT_NAMESPACE_PREFIX}enmasse -o jsonpath='{.items[*].metadata.name}'`"
 }
 
 function dump_pod_data {
@@ -12,7 +12,7 @@ function dump_pod_data {
 
     # Create a backup directory for every pod with the same name
     # as the pod
-    cp_pod_data "enmasse/${pod}:${data_dir}" "${dest}/${pod}"
+    cp_pod_data "${PRODUCT_NAMESPACE_PREFIX}enmasse/${pod}:${data_dir}" "${dest}/${pod}"
 }
 function component_dump_data {
     local archive_path="$1/archives"

--- a/templates/openshift/backup-cronjob-template.yaml
+++ b/templates/openshift/backup-cronjob-template.yaml
@@ -54,6 +54,8 @@ objects:
                       value: "${COMPONENT_SECRET_NAMESPACE}"
                     - name: PRODUCT_NAME
                       value: "${PRODUCT_NAME}"
+                    - name: PRODUCT_NAMESPACE_PREFIX
+                      value: "${PRODUCT_NAMESPACE_PREFIX}"
               restartPolicy: Never
 parameters:
   - name: NAME
@@ -65,6 +67,9 @@ parameters:
   - name: COMPONENT
     description: Component name to run the backup
     required: true
+  - name: PRODUCT_NAMESPACE_PREFIX
+    description: Namespace prefix for individual product namespaces. Empty by default. Planned to be 'openshift-' for RHMI.
+    value: ''
   - name: BACKEND
     description: Backend engine to upload the component archive
     value: s3

--- a/templates/openshift/backup-job-template.yaml
+++ b/templates/openshift/backup-job-template.yaml
@@ -51,6 +51,8 @@ objects:
                   value: "${COMPONENT_SECRET_NAMESPACE}"
                 - name: PRODUCT_NAME
                   value: "${PRODUCT_NAME}"
+                - name: PRODUCT_NAMESPACE_PREFIX
+                  value: "${PRODUCT_NAMESPACE_PREFIX}"
           restartPolicy: Never
 parameters:
   - name: NAME
@@ -62,6 +64,9 @@ parameters:
   - name: COMPONENT
     description: Component name to run the backup
     required: true
+  - name: PRODUCT_NAMESPACE_PREFIX
+    description: Namespace prefix for individual product namespaces. Empty by default. Planned to be 'openshift-' for RHMI.
+    value: ''
   - name: BACKEND
     description: Backend engine to upload the component archive
     value: s3


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/INTLY-1493

## Verification
Create backup jobs via installer with this additional params - `-e 'backup_schedule="*/1 * * * *"' -e backup_image=quay.io/integreatly/backup-container:dev`
Once the jobs are created, edit cronjobs that are affected by this PR (3scale-redis-backup, codeready-pv-backup and enmasse-pv-backup) add new env var with correct NS prefix:
```
- name: PRODUCT_NAMESPACE_PREFIX
  value: openshift-
```
Wait until the jobs get triggered and check the result of those three jobs.
Redis job should successfully back up .rdb file.
Codeready might show a warning about not finding any workspaces (optional: create one and wait until next job is triggered)
Enmasse pv cronjob might show this error if you have no data in enmasse:
`ls: cannot access /tmp/enmasse-data/*: No such file or directory` that is okay.