### PR TITLE
allow for different postgres versions

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -6,6 +6,7 @@ RUN yum --enablerepo=extras install -y epel-release && \
     yum install -y --setopt=tsflags=nodocs python-pip mysql && \
     yum install -y https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/pgdg-redhat96-9.6-3.noarch.rpm && \
     yum install -y postgresql96 && \
+    yum install -y postgresql10 && \
     yum clean all && \
     pip install -U pip && \
     pip install awscli s3cmd && \

--- a/image/tools/lib/component/postgres.sh
+++ b/image/tools/lib/component/postgres.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+function get_postgres_version {
+  echo "`oc get secret ${COMPONENT_SECRET_NAME} -n ${COMPONENT_SECRET_NAMESPACE} -o jsonpath={.data.POSTGRES_VERSION} | base64 --decode`"
+}
+
 function get_postgres_username {
   echo "`oc get secret ${COMPONENT_SECRET_NAME} -n ${COMPONENT_SECRET_NAMESPACE} -o jsonpath={.data.POSTGRES_USERNAME} | base64 --decode`"
 }
@@ -27,6 +31,13 @@ function component_dump_data {
   local POSTGRES_HOST=$(get_postgres_host)
   local POSTGRES_DATABASE=$(get_postgres_database)
   local POSTGRES_SUPERUSER=$(get_postgres_superuser)
+  local POSTGRES_VERSION=$(get_postgres_version)
+
+  if [[ -z "$POSTGRES_VERSION" ]]; then
+    POSTGRES_VERSION=9.6
+  fi
+
+  local POSTGRES_PREFIX="/usr/pgsql-${POSTGRES_VERSION}/bin"
 
   echo "*:5432:*:${POSTGRES_USERNAME}:${POSTGRES_PASSWORD}" > ~/.pgpass
   chmod 0600 ~/.pgpass
@@ -35,19 +46,19 @@ function component_dump_data {
   namespace=${POSTGRES_HOST#*.}
   namespace=${namespace%.*}
 
-  if [ "${POSTGRES_SUPERUSER}" == "true" ]; then
-    pg_dumpall --clean --if-exists --oids -U ${POSTGRES_USERNAME} -h ${POSTGRES_HOST} | gzip > ${dest}/archives/${namespace}.${ts}.pg_dumpall.gz
+  if [[ "${POSTGRES_SUPERUSER}" == "true" ]]; then
+    ${POSTGRES_PREFIX}/pg_dumpall --clean --if-exists --oids -U ${POSTGRES_USERNAME} -h ${POSTGRES_HOST} | gzip > ${dest}/archives/${namespace}.${ts}.pg_dumpall.gz
     rc=$?
-    if [ "${rc}" -ne "0" ]; then
+    if [[ "${rc}" -ne "0" ]]; then
       echo "backup of postgresql: FAILED"
       exit 1
     fi
   else
-    for db in $(psql -U ${POSTGRES_USERNAME} -h ${POSTGRES_HOST} ${POSTGRES_DATABASE} -A -t -c '\l' | cut -f1 -d'|' | grep -v '=' | grep -v 'template'); do
+    for db in $(${POSTGRES_PREFIX}/psql -U ${POSTGRES_USERNAME} -h ${POSTGRES_HOST} ${POSTGRES_DATABASE} -A -t -c '\l' | cut -f1 -d'|' | grep -v '=' | grep -v 'template'); do
       echo "dumping ${db}"
-      pg_dump --clean --if-exists --oids -U ${POSTGRES_USERNAME} -h ${POSTGRES_HOST} ${db} | gzip > ${dest}/archives/${namespace}.${db}-${ts}.pg_dump.gz
+      ${POSTGRES_PREFIX}/pg_dump --clean --if-exists --oids -U ${POSTGRES_USERNAME} -h ${POSTGRES_HOST} ${db} | gzip > ${dest}/archives/${namespace}.${db}-${ts}.pg_dump.gz
       rc=$?
-      if [ "${rc}" -ne "0" ]; then
+      if [[ "${rc}" -ne "0" ]]; then
           echo "==> Dump $db: FAILED"
           exit 1
       fi


### PR DESCRIPTION
Allow the script to work with different postgres versions. It will default to `9.6` if `POSTGRES_VERSION` is not set in the secret.

Verification steps:
1. Make sure backup is installed in your cluster
1. Delete the 3scale-postgres-backup cronjob in order to avoid confusion (not strictly required)
1. build an image from this branch and run:
```
oc new-app \
-f backup-job-template.yaml \
-p 'COMPONENT=postgres' \
-p 'COMPONENT_SECRET_NAME=threescale-postgres-secret' \
-p 'COMPONENT_SECRET_NAMESPACE=openshift-integreatly-backups' \
-p 'BACKEND_SECRET_NAME=s3-credentials' \
-p 'IMAGE=docker.io/pb82/backup-container-image:latest' \
-p 'NAME=3scale-postgres-backup' \
-p 'PRODUCT_NAME=3scale'
```
1. It should fail with the error that the pg_dump version does not match the database version. You can check the logs by getting the pods first and then using `oc logs <backup job pod name>`
1. Now edit the secret: `oc edit secret threescale-postgres-secret`
1. and add a `POSTGRES_VERSION: MTAK` to the data (MTAK is base64 for 10).
1. Delete the job and recreate it
1. Check the logs again. This time the pg dump should work. The job will likely still fail because the encryption secret is missing or invalid. But the important part is that the database dump works.