### PR TITLE
Fix broken conditional in gpg.sh

### DIFF
--- a/image/tools/lib/encryption/gpg.sh
+++ b/image/tools/lib/encryption/gpg.sh
@@ -1,6 +1,6 @@
 function check_encryption_enabled {
     local result=$(oc get secret -n ${ENCRYPTION_SECRET_NAMESPACE} ${ENCRYPTION_SECRET_NAME} -o template --template='{{.metadata.name}}')
-    if [ "$result" -eq "${ENCRYPTION_SECRET_NAME}" ]; then
+    if [ "$result" == "${ENCRYPTION_SECRET_NAME}" ]; then
         return 0
     else
         return 1


### PR DESCRIPTION
Using `if [` works differently than `if [[` (the former single square
bracket is a file, the double one is a builtin function (I think)).

When using `if [` with `-eq`, it expects numbers, but `==` can deal
with strings, which is what we want here.

Some examples:

```bash
$ if [ hello -eq hello ]; then echo yes; fi
bash: [: hello: integer expression expected

$ if [ hello == hello ]; then echo yes; fi
yes

$ if [ 1 -eq 1 ]; then echo yes; fi
yes

$ if [[ hello -eq hello ]]; then echo yes; fi
yes

$ if [[ 1 -eq 1 ]]; then echo yes; fi
yes
```

~~Note: this should at least fix the initial problem, I'm not sure if there are others further on. I'll build a custom version and try it out.~~ Edit: it works fine with this fix :+1: 