### PR TITLE
Allow defining product namespace instead of prefix

### DIFF
--- a/image/tools/lib/component/3scale-redis.sh
+++ b/image/tools/lib/component/3scale-redis.sh
@@ -13,13 +13,16 @@ function save {
 }
 
 function component_dump_data {
+    if [[ -z "${PRODUCT_NAMESPACE:-}" ]]; then
+        PRODUCT_NAMESPACE="${PRODUCT_NAMESPACE_PREFIX}3scale"
+    fi
     save
     local ts=$(date '+%H_%M_%S')
     dest_file="$1/archives/dump-${ts}.rdb"
     dump_rdb_path="/var/lib/redis/data/dump.rdb"
 
     oc projects
-    redis_pod_name=$(oc get pods -l deploymentConfig=backend-redis -o name -n ${PRODUCT_NAMESPACE_PREFIX}3scale | sed -e 's/^pod\///')
+    redis_pod_name=$(oc get pods -l deploymentConfig=backend-redis -o name -n ${PRODUCT_NAMESPACE} | sed -e 's/^pod\///')
 
-    cp_pod_data "${PRODUCT_NAMESPACE_PREFIX}3scale/${redis_pod_name}:${dump_rdb_path}" "${dest_file}"
+    cp_pod_data "${PRODUCT_NAMESPACE}/${redis_pod_name}:${dump_rdb_path}" "${dest_file}"
 }

--- a/image/tools/lib/component/codeready_pv.sh
+++ b/image/tools/lib/component/codeready_pv.sh
@@ -11,7 +11,7 @@ function component_dump_data {
     if [[ -z "${PRODUCT_NAMESPACE:-}" ]]; then
         PRODUCT_NAMESPACE="${PRODUCT_NAMESPACE_PREFIX}codeready"
     fi
-    local pods="$(oc get pods -n ${PRODUCT_NAMESPACE} --no-headers=true -l "che.workspace_id" | awk '{print $1}')"
+    local pods="$(oc get pods -n ${PRODUCT_NAMESPACE} --no-headers=true -l "che.workspace_id,che.original_name notin (che-jwtproxy)" | awk '{print $1}')"
     if [ "${#pods}" -eq "0" ]; then
         echo "=>> No workspaces found to backup"
         exit 0

--- a/image/tools/lib/component/codeready_pv.sh
+++ b/image/tools/lib/component/codeready_pv.sh
@@ -11,7 +11,7 @@ function component_dump_data {
     if [[ -z "${PRODUCT_NAMESPACE:-}" ]]; then
         PRODUCT_NAMESPACE="${PRODUCT_NAMESPACE_PREFIX}codeready"
     fi
-    local pods="$(oc get pods -n ${PRODUCT_NAMESPACE} | grep workspace | awk '{print $1}')"
+    local pods="$(oc get pods -n ${PRODUCT_NAMESPACE} --no-headers=true -l "che.workspace_id" | awk '{print $1}')"
     if [ "${#pods}" -eq "0" ]; then
         echo "=>> No workspaces found to backup"
         exit 0

--- a/image/tools/lib/component/codeready_pv.sh
+++ b/image/tools/lib/component/codeready_pv.sh
@@ -4,11 +4,14 @@ function dump_pod_data {
     workspace_pod_name=$1
     dump_dest=$2
     workspace_id=$(echo ${workspace_pod_name} | awk -F"." '{ print $1}')
-    cp_pod_data "${PRODUCT_NAMESPACE_PREFIX}codeready/${workspace_pod_name}:/projects" "${dump_dest}/${workspace_id}"
+    cp_pod_data "${PRODUCT_NAMESPACE}/${workspace_pod_name}:/projects" "${dump_dest}/${workspace_id}"
 }
 
 function component_dump_data {
-    local pods="$(oc get pods -n ${PRODUCT_NAMESPACE_PREFIX}codeready | grep workspace | awk '{print $1}')"
+    if [[ -z "${PRODUCT_NAMESPACE:-}" ]]; then
+        PRODUCT_NAMESPACE="${PRODUCT_NAMESPACE_PREFIX}codeready"
+    fi
+    local pods="$(oc get pods -n ${PRODUCT_NAMESPACE} | grep workspace | awk '{print $1}')"
     if [ "${#pods}" -eq "0" ]; then
         echo "=>> No workspaces found to backup"
         exit 0

--- a/image/tools/lib/component/enmasse_pv.sh
+++ b/image/tools/lib/component/enmasse_pv.sh
@@ -2,7 +2,7 @@
 
 # Brokered pods have a storage PV attached. They are labelled with role=broker
 function get_broker_pods {
-    echo "`oc get pods --selector='role=broker' -n ${PRODUCT_NAMESPACE_PREFIX}enmasse -o jsonpath='{.items[*].metadata.name}'`"
+    echo "`oc get pods --selector='role=broker' -n ${PRODUCT_NAMESPACE} -o jsonpath='{.items[*].metadata.name}'`"
 }
 
 function dump_pod_data {
@@ -12,9 +12,12 @@ function dump_pod_data {
 
     # Create a backup directory for every pod with the same name
     # as the pod
-    cp_pod_data "${PRODUCT_NAMESPACE_PREFIX}enmasse/${pod}:${data_dir}" "${dest}/${pod}"
+    cp_pod_data "${PRODUCT_NAMESPACE}/${pod}:${data_dir}" "${dest}/${pod}"
 }
 function component_dump_data {
+    if [[ -z "${PRODUCT_NAMESPACE:-}" ]]; then
+        PRODUCT_NAMESPACE="${PRODUCT_NAMESPACE_PREFIX}enmasse"
+    fi
     local archive_path="$1/archives"
     local dump_dest="/tmp/enmasse-data"
     local pods=$(get_broker_pods)


### PR DESCRIPTION
This change is added to allow setting product namespace name directly, instead of relying on hard-coded suffix values. 
Motivation: on 4.x we use "amq-online" ns name instead of enmasse.

Second change is for CodeReady workspaces backup - improved filtering of the pods, to avoid matching an OLM pod ("registry-cs-rhmi-codeready-workspaces-w8kjm").

This should be backwards compatible with 1.x, but that needs to be thoroughly tested.