### PR TITLE
INTLY-3934 - add timestamp to scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ IMAGE=backup-container
 TAG=latest
 
 image/build:
-	@(cd image; docker build -t ${REG}/${ORG}/${IMAGE}:${TAG} .)
+	@docker build -t ${REG}/${ORG}/${IMAGE}:${TAG} ./image
 
 image/push:
 	@docker push ${REG}/${ORG}/${IMAGE}:${TAG}

--- a/image/tools/entrypoint.sh
+++ b/image/tools/entrypoint.sh
@@ -29,7 +29,7 @@ if [[ "$debug" ]]; then
 fi
 
 if [[ -z "$component" ]]; then
-    (>&2 echo 'Please specify a component using "-c"')
+    (>&2 timestamp_echo 'Please specify a component using "-c"')
     exit 1
 fi
 
@@ -46,12 +46,14 @@ ARCHIVES_DEST=$DEST/archives
 mkdir -p $DEST $ARCHIVES_DEST
 export HOME=$DEST
 
+timestamp_echo "Starting backup"
+
 component_dump_data $DEST
 if [ "$?" -ne "0" ]; then
-    echo "==> Component data dump failed"
+    timestamp_echo "Component data dump failed"
     exit 1
 fi
-echo '==> Component data dump completed'
+timestamp_echo "Component data dump completed"
 
 if [[ "$encryption_engine" ]]; then
     check_encryption_enabled
@@ -59,13 +61,13 @@ if [[ "$encryption_engine" ]]; then
         encrypt_prepare ${DEST}
         encrypted_files="$(encrypt_archive $ARCHIVES_DEST)"
         if [ "$?" -ne "0" ]; then
-            echo "==> Encryption failed"
+            timestamp_echo "Encryption failed"
             exit 1
         fi
 
-        echo '==> Data encryption completed'
+        timestamp_echo "Data encryption completed"
     else
-        echo "==> encryption secret not found. Skipping"
+        timestamp_echo "Encryption secret not found. Skipping"
         encrypted_files="$ARCHIVES_DEST/*"
     fi
 else
@@ -74,13 +76,15 @@ fi
 
 upload_archive "${encrypted_files}" $DATESTAMP backups/$PRODUCT_NAME/$component
 if [ "$?" -ne "0" ]; then
-    echo "==> Archive upload failed"
+    timestamp_echo "Archive upload failed"
     exit 1
 fi
 
-echo "[$DATESTAMP] Backup completed"
+timestamp_echo "[$DATESTAMP] Backup completed"
 
 if [[ "$debug" ]]; then
-    echo '==> Debug flag detected - will sleep for all eternity'
+    timestamp_echo "Debug flag detected - will sleep for all eternity"
     sleep infinity
 fi
+
+timestamp_echo "Finished Backup"

--- a/image/tools/lib/backend/s3.sh
+++ b/image/tools/lib/backend/s3.sh
@@ -20,9 +20,11 @@ function get_s3_access_key {
 }
 
 function upload_archive {
+    timestamp_echo "Starting upload"
+    
     check_backup_enabled
     if [ "$?" -eq "1" ]; then
-        echo "==> backend secret not found. Skipping"
+        timestamp_echo "backend secret not found. Skipping"
         return 0
     fi
 
@@ -42,12 +44,12 @@ function upload_archive {
             s3cmd put --access_key ${AWS_ACCESS_KEY_ID} --secret_key ${AWS_SECRET_ACCESS_KEY} --progress ${fname} "s3://$AWS_S3_BUCKET_NAME/$bucket_folder/$datestamp/$(basename ${fname})"
             rc=$?
             if [ "${rc}" -ne "0" ]; then
-                echo "==> Upload $fname: FAILED"
+                timestamp_echo "Upload $fname: FAILED"
                 exit 1
             fi
-            echo "==> Upload ${fname} completed"
+            timestamp_echo "Upload ${fname} completed"
         else
-            echo "==> No backups in ${fname} to upload"
+            timestamp_echo "No backups in ${fname} to upload"
         fi
     done
 }

--- a/image/tools/lib/component/codeready_pv.sh
+++ b/image/tools/lib/component/codeready_pv.sh
@@ -8,12 +8,14 @@ function dump_pod_data {
 }
 
 function component_dump_data {
+    timestamp_echo "Dumping codeready component data"
+
     if [[ -z "${PRODUCT_NAMESPACE:-}" ]]; then
         PRODUCT_NAMESPACE="${PRODUCT_NAMESPACE_PREFIX}codeready"
     fi
     local pods="$(oc get pods -n ${PRODUCT_NAMESPACE} --no-headers=true -l "che.workspace_id,che.original_name notin (che-jwtproxy)" | awk '{print $1}')"
     if [ "${#pods}" -eq "0" ]; then
-        echo "=>> No workspaces found to backup"
+        timestamp_echo "No workspaces found to backup"
         exit 0
     fi
 

--- a/image/tools/lib/component/enmasse_pv.sh
+++ b/image/tools/lib/component/enmasse_pv.sh
@@ -23,14 +23,14 @@ function component_dump_data {
     local pods=$(get_broker_pods)
 
     if [ "${#pods}" -eq "0" ]; then
-        echo "=>> No broker pods found to backup"
+        timestamp_echo "No broker pods found to backup"
         exit 0
     fi
 
     mkdir -p ${dump_dest}
 
     for pod in ${pods}; do
-        echo "==> processing enmasse broker pod ${pod}"
+        timestamp_echo "Processing enmasse broker pod ${pod}"
         dump_pod_data ${pod} ${dump_dest}
     done
 
@@ -40,6 +40,6 @@ function component_dump_data {
         tar -zcvf "$archive_path/enmasse-pv-data-${ts}.tar.gz" -C $dump_dest .
         rm -rf $dump_dest
     else
-        echo "==> no enmasse broker data to backup"
+        timestamp_echo "No enmasse broker data to backup"
     fi
 }

--- a/image/tools/lib/component/mysql.sh
+++ b/image/tools/lib/component/mysql.sh
@@ -24,7 +24,7 @@ function component_dump_data {
 
     check_mysql_backup_enabled
     if [[ $? -eq 1 ]]; then
-        echo "==> mysql secret not found in default namespace. Skipping"
+        timestamp_echo "Mysql secret not found in default namespace. Skipping"
         exit 0
     fi
 
@@ -39,7 +39,7 @@ function component_dump_data {
         mysqldump --single-transaction -h${MYSQL_HOST} -u${MYSQL_USER} -p${MYSQL_PASSWORD} -R ${database} | gzip > ${dest}/archives/${database}-${ts}.dump.gz
         local rc=$?
         if [ "${rc}" -ne "0" ]; then
-            echo "==> Dump $database: FAILED"
+            timestamp_echo "Dump $database: FAILED"
             exit 1
         fi
     done

--- a/image/tools/lib/component/postgres.sh
+++ b/image/tools/lib/component/postgres.sh
@@ -50,7 +50,7 @@ function component_dump_data {
     ${POSTGRES_PREFIX}/pg_dumpall --clean --if-exists --oids -U ${POSTGRES_USERNAME} -h ${POSTGRES_HOST} | gzip > ${dest}/archives/${namespace}.${ts}.pg_dumpall.gz
     rc=$?
     if [[ "${rc}" -ne "0" ]]; then
-      echo "backup of postgresql: FAILED"
+      timestamp_echo "Backup of postgresql: FAILED"
       exit 1
     fi
   else
@@ -61,11 +61,11 @@ function component_dump_data {
         continue
       fi
 
-      echo "dumping ${db}"
+      timestamp_echo "dumping ${db}"
       ${POSTGRES_PREFIX}/pg_dump --clean --if-exists --oids -U ${POSTGRES_USERNAME} -h ${POSTGRES_HOST} ${db} | gzip > ${dest}/archives/${namespace}.${db}-${ts}.pg_dump.gz
       rc=$?
       if [[ "${rc}" -ne "0" ]]; then
-          echo "==> Dump $db: FAILED"
+          timestamp_echo "Dump $db: FAILED"
           exit 1
       fi
     done

--- a/image/tools/lib/component/resources.sh
+++ b/image/tools/lib/component/resources.sh
@@ -14,7 +14,7 @@ function check_resource {
     # least two lines: one for the header and one for each
     # resource found
     if [ "$result"  -eq "1" ]; then
-        echo "==> No $type in $ns to back up"
+        timestamp_echo "No $type in $ns to back up"
         return 1
     else
         return 0
@@ -34,7 +34,7 @@ function backup_resource {
     set +eo pipefail
     check_resource ${type} ${ns}
     if [ "$?" -eq "0" ]; then
-        echo "==> backing up $type in $ns"
+        timestamp_echo "backing up $type in $ns"
         if [ "$loop" == "y" ]; then
             for obj in $(oc get ${type} -n ${ns} | tr -s ' ' | cut -d ' ' -f 1 |  tail -n +2); do
                 echo "$(oc get ${type}/${obj} -n ${ns} -o yaml --export)" > ${dest}/archives/${ns}-${type}.${obj}.yaml
@@ -51,7 +51,7 @@ function backup_resource {
 function backup_namespace {
     local ns=$1
     local dest=$2
-    echo "==> backing up namespace $ns"
+    timestamp_echo "Backing up namespace $ns"
     oc get namespace ${ns} -o yaml --export | gzip > ${dest}/archives/${ns}-namespace.yaml.gz
 }
 
@@ -60,7 +60,7 @@ function backup_namespace {
 function backup_service_accounts {
     local ns=$1
     local dest=$2
-    echo "==> backing up service accounts in $ns"
+    timestamp_echo "Backing up service accounts in $ns"
     oc get serviceaccounts -n ${ns} --field-selector='metadata.name!=builder,metadata.name!=deployer,metadata.name!=default' -o yaml --export | gzip > ${dest}/archives/${ns}-sa.yaml.gz
 }
 
@@ -68,7 +68,7 @@ function backup_service_accounts {
 function backup_role_bindings {
     local ns=$1
     local dest=$2
-    echo "==> backing up role bindings in $ns"
+    timestamp_echo "Backing up role bindings in $ns"
     oc get rolebindings -n ${ns} --field-selector='metadata.name!=system:deployers,metadata.name!=system:image-builders,metadata.name!=system:image-pullers' -o yaml --export | gzip > ${dest}/archives/${ns}-rb.yaml.gz
 }
 
@@ -76,7 +76,7 @@ function backup_role_bindings {
 function backup_cluster_resource {
     local type=$1
     local dest=$2
-    echo "==> backing up cluster resource $type"
+    timestamp_echo "Backing up cluster resource $type"
     oc get ${type} -o yaml --export | gzip > ${dest}/archives/${type}.yaml.gz
 }
 
@@ -96,7 +96,7 @@ function component_dump_data {
     local namespaces=$(get_middleware_namespaces)
 
     for ns in ${namespaces} "default"; do
-        echo "==> processing namespace $ns"
+        timestamp_echo "Processing namespace $ns"
         backup_resource secrets ${ns} ${dest}
         backup_resource configmaps ${ns} ${dest}
         backup_resource services ${ns} ${dest}
@@ -150,7 +150,7 @@ function component_dump_data {
         backup_namespace ${ns} ${dest}
     done
 
-    echo "==> processing cluster resources"
+    timestamp_echo "Processing cluster resources"
 
     # These resources are not located in a particular namespace
     backup_cluster_resource oauthclients ${dest}

--- a/image/tools/lib/encryption/gpg.sh
+++ b/image/tools/lib/encryption/gpg.sh
@@ -39,7 +39,7 @@ function encrypt_archive {
         gpg --no-tty --batch --yes --encrypt --recipient "$recipient" --trust-model ${trust} ${fname}
         rc=$?
         if [[ ${rc} -ne 0 ]]; then
-            echo "==> Encrypt $fname: FAILED"
+            timestamp_echo "Encrypt $fname: FAILED"
             exit 1
         fi
     done

--- a/image/tools/lib/utils.sh
+++ b/image/tools/lib/utils.sh
@@ -10,9 +10,13 @@ function cp_pod_data {
     # Check if any files were rewritten to during oc cp, and copy it again if it was.
     while [[ $copy_output == *"file changed as we read it"* ]] && [ $num_attempted_copy -lt $max_tries ]
     do
-       echo "A file has been overwritten during copying, executing 'oc cp' again"
+       timestamp_echo "A file has been overwritten during copying, executing 'oc cp' again"
        sleep 5
        copy_output=$(oc cp $pod_data_src $cp_dest)
        ((num_attempted_copy++))
     done
+}
+
+function timestamp_echo {
+    echo `(date -u '+%Y-%m-%d %H:%M:%S')` '==>' $1
 }


### PR DESCRIPTION
## Description
Adds timestamps to the relevant echo logs to have a better idea on timing / duration when performing a backup

Jira
* https://issues.redhat.com/browse/INTLY-3934

## Verification
* Provision integreatly workshop with OS3 installed
* Run the `install_backup` from the [installation repo](https://github.com/integr8ly/installation/blob/master/playbooks/install_backups.yml) to install the backup cronjobs
```
ansible-playbook playbooks/install_backups.yml -e backup_s3_aws_access_key=<YOUR_S3_ACCESS_KEY> -e backup_s3_aws_secret_key=<YOUR_S3_SECRET_KEY> -e backup_s3_aws_bucket=<YOUR_S3_NAME> -e 'ns_prefix=' -e backup_image=quay.io/kevfan/backup-container:latest
```
* Scale down the ups operator to 0 to prevent it from reconciling back to hardcoded value
```
oc edit deployment unifiedpush-operator -n mobile-unifiedpush
```
* Edit the cronjob in the ups namespace to use `quay.io/kevfan/backup-container:latest`
```
oc edit cronjob ups-daily-at-midnight -n mobile-unifiedpush
```
* Scale down the sso operator to 0 to prevent it from reconciling back to hardcoded value
```
oc edit deployment keycloak-operator -n sso
```
* Edit the cronjob in the sso namespace to use `quay.io/kevfan/backup-container:latest`
```
 oc edit cronjob daily-at-midnight-sso -n sso
```
* Run the following backup jobs (taken from [backup SOPs](https://github.com/RHCloudServices/integreatly-help/tree/master/sops/backup/in_cluster), ensuring the there is now some timestamps to the logs and finishes successfully uploading the backup without error 
```
oc create job 3scale-mysql-backup-$(date +"%Y-%m-%d-%H%M%S") --from=cronjob/3scale-mysql-backup -n openshift-integreatly-backups
oc create job 3scale-postgres-backup-$(date +"%Y-%m-%d-%H%M%S") --from=cronjob/3scale-postgres-backup -n openshift-integreatly-backups
oc create job 3scale-redis-backup-$(date +"%Y-%m-%d-%H%M%S") --from=cronjob/3scale-redis-backup -n openshift-integreatly-backups
oc create job enmasse-postgres-backup-$(date +"%Y-%m-%d-%H%M%S") --from=cronjob/enmasse-postgres-backup -n openshift-integreatly-backups
oc create job enmasse-pv-backup-$(date +"%Y-%m-%d-%H%M%S") --from=cronjob/enmasse-pv-backup -n openshift-integreatly-backups
oc create job codeready-postgres-backup-$(date +"%Y-%m-%d-%H%M%S") --from=cronjob/codeready-postgres-backup -n openshift-integreatly-backups
oc create job codeready-pv-backup-$(date +"%Y-%m-%d-%H%M%S") --from=cronjob/codeready-pv-backup -n openshift-integreatly-backups
oc create job fuse-postgres-backup-$(date +"%Y-%m-%d-%H%M%S") --from=cronjob/fuse-postgres-backup -n openshift-integreatly-backups
oc create job launcher-postgres-backup-$(date +"%Y-%m-%d-%H%M%S") --from=cronjob/launcher-postgres-backup -n openshift-integreatly-backups
oc create job resources-backup-$(date +"%Y-%m-%d-%H%M%S") --from=cronjob/resources-backup -n openshift-integreatly-backups
oc create job ups-postgres-backup-$(date +"%Y-%m-%d-%H%M%S") --from=cronjob/ups-daily-at-midnight -n openshift-mobile-unifiedpush
```