### PR TITLE
fix: fails backup on permissions error

### DIFF
--- a/image/tools/lib/component/enmasse_pv.sh
+++ b/image/tools/lib/component/enmasse_pv.sh
@@ -20,7 +20,12 @@ function component_dump_data {
     fi
     local archive_path="$1/archives"
     local dump_dest="/tmp/enmasse-data"
-    local pods=$(get_broker_pods)
+    local pods=$(get_broker_pods 2>&1)
+
+    if [[ "$pods" == *"Error from server"* ]]; then
+        echo ${pods}
+        exit 1
+    fi
 
     if [ "${#pods}" -eq "0" ]; then
         timestamp_echo "No broker pods found to backup"


### PR DESCRIPTION
Makes the container exit with an error when an error occurs

https://issues.redhat.com/browse/INTLY-4625

### Verification steps

1) Rebuild the image and push to your quay.io account

2) Change the reference of the backup container image on RHMI [1.x](https://github.com/integr8ly/installation/blob/master/inventories/group_vars/all/manifest.yaml#L128) and [2.x](https://github.com/integr8ly/integreatly-operator/blob/master/pkg/resources/backup.go#L221) and run an install

3) Remove permission to list pods on amq-online role

4) Run a backup job on RHMI 1.x and 2.x 
eg.: ` oc create job --from=cronjob/enmasse-pv-backup <job_name> -n namespace`

5) Ensure backup job fails 