### PR TITLE
fix: crw 2.0 requires backing up non-default container inside a pod

### DIFF
--- a/image/tools/lib/component/codeready_pv.sh
+++ b/image/tools/lib/component/codeready_pv.sh
@@ -4,7 +4,7 @@ function dump_pod_data {
     workspace_pod_name=$1
     dump_dest=$2
     workspace_id=$(echo ${workspace_pod_name} | awk -F"." '{ print $1}')
-    cp_pod_data "${PRODUCT_NAMESPACE}/${workspace_pod_name}:/projects" "${dump_dest}/${workspace_id}"
+    cp_container_data "${workspace_pod_name}" "${PRODUCT_NAMESPACE}/${workspace_pod_name}:/projects" "${dump_dest}/${workspace_id}"
 }
 
 function component_dump_data {

--- a/image/tools/lib/utils.sh
+++ b/image/tools/lib/utils.sh
@@ -17,6 +17,39 @@ function cp_pod_data {
     done
 }
 
+# Backup every container inside a pod
+function cp_container_data {
+    pod_name=$1
+    pod_data_src=$2
+    cp_dest=$3
+
+    # Get a list of containers inside the pod
+    containers=$(oc get pods "$pod_name" -ojsonpath='{.spec.containers[*].name}' -n "${PRODUCT_NAMESPACE}")
+
+    for container in ${containers}; do
+      container_dest="$cp_dest-$container"
+      timestamp_echo "backing up container $container in pod $pod_name"
+      num_attempted_copy=0
+      max_tries=5
+
+      # Disable errors because some of the containers might not have the directory to back up
+      set +eo pipefail
+
+      copy_output=$(oc cp "$pod_data_src" "$container_dest" -c "$container")
+      # Check if any files were rewritten to during oc cp, and copy it again if it was.
+      while [[ $copy_output == *"file changed as we read it"* ]] && [ $num_attempted_copy -lt $max_tries ]
+      do
+         timestamp_echo "A file has been overwritten during copying, executing 'oc cp' again"
+         sleep 5
+         copy_output=$(oc cp "$pod_data_src" "$container_dest" -c "$container")
+         ((num_attempted_copy++))
+      done
+
+      # Re-enable errors
+      set -eo pipefail
+    done
+}
+
 function timestamp_echo {
     echo `(date -u '+%Y-%m-%d %H:%M:%S')` '==>' $1
 }


### PR DESCRIPTION
Implement container backup that backs up every container inside a pod. This has become necessary since CRW 2.0 because the projects directory is no longer in the default container.

Verification steps:

1. Get a cluster with RHMI installed
2. In the `redhat-rhmi-codeready-workspaces` namespace edit the cronjob for creating PV backups: `oc edit cronjobs codeready-pv-backup`
3. Replace the backup image with `quay.io/pb82/backup-container-image:latest`
4. Make sure that a workspace pod in CRW exists. If not open CRW and create a workspace.
5. Launch a backup job manually: `oc create job codeready-pv-backup-$(date +"%Y-%m-%d-%H%M%S") --from=cronjob/codeready-pv-backup -n redhat-rhmi-codeready-workspaces`
6. Check the logs of the backup pod and make sure workspace files are actually backed up: `oc logs <backup pod name>`