### PR TITLE
Increase the fault tolerance when backing up a large nuber of files 

### DIFF
--- a/image/tools/lib/utils.sh
+++ b/image/tools/lib/utils.sh
@@ -6,6 +6,11 @@ function cp_pod_data {
 
     num_attempted_copy=0
     max_tries=5
+
+    # Disable errors because files contains may change during backups, which is acceptable and expected in production
+    # JIRA: https://issues.redhat.com/browse/INTLY-10129
+    set +eo pipefail
+
     copy_output=$(oc cp $pod_data_src $cp_dest)
     # Check if any files were rewritten to during oc cp, and copy it again if it was.
     while [[ $copy_output == *"file changed as we read it"* ]] && [ $num_attempted_copy -lt $max_tries ]
@@ -15,6 +20,9 @@ function cp_pod_data {
        copy_output=$(oc cp $pod_data_src $cp_dest)
        ((num_attempted_copy++))
     done
+
+    # Re-enable errors
+    set -eo pipefail
 }
 
 # Backup every container inside a pod

--- a/image/tools/lib/utils.sh
+++ b/image/tools/lib/utils.sh
@@ -5,7 +5,7 @@ function cp_pod_data {
     cp_dest=$2
 
     num_attempted_copy=0
-    max_tries=5
+    max_tries=3
 
     # Disable errors because files contains may change during backups, which is acceptable and expected in production
     # JIRA: https://issues.redhat.com/browse/INTLY-10129
@@ -38,7 +38,7 @@ function cp_container_data {
       container_dest="$cp_dest-$container"
       timestamp_echo "backing up container $container in pod $pod_name"
       num_attempted_copy=0
-      max_tries=5
+      max_tries=3
 
       # Disable errors because some of the containers might not have the directory to back up
       set +eo pipefail


### PR DESCRIPTION
In this PR 3 issues raise in the linked Jiras are been address.
1. Running out of storage space while doing emmase backs. Cause is believed to be from the storage drive running out of inodes when backing up multiply pods containing a large number of small files. Fix is the batch this work for each pod.
2. `oc cp` causing the script to exit with status code 1. Random `oc op` will give a Exit code of 1, There was no reason found for this to happen. This was seen to happen 3 times when copying 100,000 test files in over 500+ runs. Fix is to set the script to ignore the error and continue.
3. Reduce the number of retire attempts from 5 to 3. If `oc cp` detects a file change during the copy the old file does get copied but warns of the change in the file. We rerun the `oc cp` to get the more update file. Reducing the number of times this happens to 3 times still ensures we get a "as fresh as can be" copy of all the files with out running longer than needs be. Aim is to keep the copy inside a 10 minute alert window.

*JIRA:* 
https://issues.redhat.com/browse/INTLY-10129 
https://issues.redhat.com/browse/INTLY-10158