### PR TITLE
Reduce inode usage during PV backup & only retry if failed

### DIFF
--- a/image/tools/lib/utils.sh
+++ b/image/tools/lib/utils.sh
@@ -5,7 +5,8 @@ function cp_pod_data {
     cp_dest=$2
 
     num_attempted_copy=0
-    max_tries=5
+    max_tries=3
+
     copy_output=$(oc cp $pod_data_src $cp_dest)
     # Check if any files were rewritten to during oc cp, and copy it again if it was.
     while [[ $copy_output == *"file changed as we read it"* ]] && [ $num_attempted_copy -lt $max_tries ]
@@ -30,7 +31,7 @@ function cp_container_data {
       container_dest="$cp_dest-$container"
       timestamp_echo "backing up container $container in pod $pod_name"
       num_attempted_copy=0
-      max_tries=5
+      max_tries=3
 
       # Disable errors because some of the containers might not have the directory to back up
       set +eo pipefail

--- a/image/tools/lib/utils.sh
+++ b/image/tools/lib/utils.sh
@@ -7,13 +7,15 @@ function cp_pod_data {
     num_attempted_copy=0
     max_tries=3
 
-    copy_output=$(oc cp $pod_data_src $cp_dest)
-    # Check if any files were rewritten to during oc cp, and copy it again if it was.
-    while [[ $copy_output == *"file changed as we read it"* ]] && [ $num_attempted_copy -lt $max_tries ]
+    oc cp $pod_data_src $cp_dest
+    ret=$?
+
+    while [[ $ret != 0 && $num_attempted_copy -lt $max_tries ]]
     do
-       timestamp_echo "A file has been overwritten during copying, executing 'oc cp' again"
+       timestamp_echo "'oc cp' failed with exit code ${ret}, will retry in 5 seconds, attempt ${num_attempted_copy} of ${max_tries}"
        sleep 5
-       copy_output=$(oc cp $pod_data_src $cp_dest)
+       oc cp $pod_data_src $cp_dest
+       ret=$?
        ((num_attempted_copy++))
     done
 }
@@ -36,13 +38,15 @@ function cp_container_data {
       # Disable errors because some of the containers might not have the directory to back up
       set +eo pipefail
 
-      copy_output=$(oc cp "$pod_data_src" "$container_dest" -c "$container")
+      oc cp "$pod_data_src" "$container_dest" -c "$container"
+      ret=$?
       # Check if any files were rewritten to during oc cp, and copy it again if it was.
-      while [[ $copy_output == *"file changed as we read it"* ]] && [ $num_attempted_copy -lt $max_tries ]
+      while [[ $ret != 0 && $num_attempted_copy -lt $max_tries ]]
       do
-         timestamp_echo "A file has been overwritten during copying, executing 'oc cp' again"
+         timestamp_echo "'oc cp' failed with exit code ${ret}, will retry in 5 seconds, attempt ${num_attempted_copy} of ${max_tries}"
          sleep 5
-         copy_output=$(oc cp "$pod_data_src" "$container_dest" -c "$container")
+         oc cp "$pod_data_src" "$container_dest" -c "$container"
+         ret=$?
          ((num_attempted_copy++))
       done
 


### PR DESCRIPTION
JIRA:
https://issues.redhat.com/browse/INTLY-10129
https://issues.redhat.com/browse/INTLY-10158

This PR replaces #59.

### Verification

There are a couple of cases that need to be verified here (please add additional ones you think are necessary):

- [ ] It doesn't fail when there are no broker pods (instead exits early without doing anything meaningful)
- [ ] It successfully backs up the data when there are one or more broker pods
- [ ] The archive created from these changes resembles the archive created by the current version before these changes

#### Suggested steps on a new integreatly cluster

* Update the `backups-s3-credentials` secret in the `redhat-rhmi-amq-online` namespace with valid values (create a bucket in s3 for it also) so that the backup archives can be uploaded there successfully, otherwise the job will fail repeatedly.

* Before creating any broker pods, attempt a backup, which should exit cleanly, proving that it works before these changes. E.g. the following on an integreatly cluster:

```
oc create job enmasse-pv-backup-$(date +"%Y-%m-%d-%H%M%S") --from=cronjob/enmasse-pv-backup -n redhat-rhmi-amq-online
```

*  Create a couple of brokered address spaces in some namespace:

```yaml
oc apply -f - << EOF 
apiVersion: enmasse.io/v1beta1
kind: AddressSpace
metadata:
  name: test1
spec:
  authenticationService:
    name: none-authservice
  plan: brokered-single-broker
  type: brokered
apiVersion: enmasse.io/v1beta1
kind: AddressSpace
metadata:
  name: test2
spec:
  authenticationService:
    name: none-authservice
  plan: brokered-single-broker
  type: brokered

EOF
```

* Wait for the broker pods to become ready in the enmasse namespace. E.g.:

```
oc get pods --selector='role=broker' -n redhat-rhmi-amq-online

NAME                              READY   STATUS    RESTARTS   AGE
broker.2d65585-6f7cf86c77-wrz8c   1/1     Running   0          17h
broker.ab960db-56f88745df-4d6pz   1/1     Running   0          21h

```

* Run another backup:

```
oc create job enmasse-pv-backup-$(date +"%Y-%m-%d-%H%M%S") --from=cronjob/enmasse-pv-backup -n redhat-rhmi-amq-online
```

* Update the cronjob with the new image containing these changes (note, first stop the integreatly operator to ensure it doesn't reconcile it back):

```
oc patch cronjob/enmasse-pv-backup -n redhat-rhmi-amq-online --type='json' -p='[{"op": "replace", "path": "/spec/jobTemplate/spec/template/spec/containers/0/image", "value":"quay.io/grdryn/backup-container:67cd860"}]'
```

* RUN ANOTHER BACKUP

```
oc create job enmasse-pv-backup-$(date +"%Y-%m-%d-%H%M%S") --from=cronjob/enmasse-pv-backup -n redhat-rhmi-amq-online
```

* Download the two archives from s3 for the 2 backups performed above, and extract them and make sure that they're of a similar size and have a similar structure (so that any existing restoration SOP works as before)

* Delete the two address spaces created earlier from whatever namespace you created them in, and wait for the broker pods to disappear from the `redhat-rhmi-amq-online` namespace.

* Run another backup (should complete successfully without creating a backup archive since there are no broker pods)

```
oc create job enmasse-pv-backup-$(date +"%Y-%m-%d-%H%M%S") --from=cronjob/enmasse-pv-backup -n redhat-rhmi-amq-online
```

* Delete the bucket from s3 and remove your details from the `backups-s3-credentials` in the `redhat-rhmi-amq-online` namespace